### PR TITLE
Improve ErrorMessage for RequiredIf

### DIFF
--- a/Foolproof/RequiredIf.cs
+++ b/Foolproof/RequiredIf.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 
 namespace Foolproof
 {
@@ -7,6 +11,8 @@ namespace Foolproof
     {
         public Operator Operator { get; private set; }
         public object DependentValue { get; private set; }
+        public string DependentValueDisplayName { get; private set; }
+
         protected OperatorMetadata Metadata { get; private set; }
         
         public RequiredIfAttribute(string dependentProperty, Operator @operator, object dependentValue)
@@ -15,6 +21,7 @@ namespace Foolproof
             Operator = @operator;
             DependentValue = dependentValue;
             Metadata = OperatorMetadata.Get(Operator);
+            DependentValueDisplayName = GetDisplayName(dependentValue);
         }
 
         public RequiredIfAttribute(string dependentProperty, object dependentValue)
@@ -24,8 +31,8 @@ namespace Foolproof
         {
             if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
                 ErrorMessage = DefaultErrorMessage;
-
-            return string.Format(ErrorMessageString, name, DependentProperty, DependentValue);
+            DependentValueDisplayName = GetDisplayName(DependentValue);
+            return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, DependentValueDisplayName ?? DependentValue);
         }
 
         public override string ClientTypeName
@@ -53,6 +60,24 @@ namespace Foolproof
         public override string DefaultErrorMessage
         {
             get { return "{0} is required due to {1} being " + Metadata.ErrorMessage + " {2}"; }
+        }
+
+        public string GetDisplayName(object value)
+        {
+            Type type = value.GetType();
+            var members = (from member in type.GetMembers()
+                          from attribute in member.GetCustomAttributes(typeof(DisplayAttribute), true)
+                          select member).ToList();
+
+            if (members != null && members.Count >= 1)
+            {
+                object[] attributes = members[0].GetCustomAttributes(typeof(DisplayAttribute), false);
+                if (attributes != null && attributes.Length >= 1)
+                {
+                    return ((DisplayAttribute)attributes[0]).Name;
+                }
+            }
+            return string.Format("{0}", value);
         }
     }
 }


### PR DESCRIPTION
Improve ErrorMessage for RequiredIf to use DependentPropertyDisplayName and resolve DisplayNames for Values (e.g. Enum)