### PR TITLE
Correct the javascript passOnNull check

### DIFF
--- a/Foolproof/Client Scripts/MvcFoolproofJQueryValidation.js
+++ b/Foolproof/Client Scripts/MvcFoolproofJQueryValidation.js
@@ -1,6 +1,6 @@
 ﻿var foolproof = function () { };
 foolproof.is = function (value1, operator, value2, passOnNull) {
-    if (passOnNull) {
+    if (passOnNull === "true") {
         var isNullish = function (input) {
             return input == null || input == undefined || input == "";
         };
@@ -75,7 +75,7 @@ __MVC_ApplyValidator_Unknown = function (rules, type, params) {
 jQuery.validator.addMethod("is", function (value, element, params) {
     var dependentProperty = foolproof.getId(element, params["dependentproperty"]);
     var operator = params["operator"];
-    var passOnNull = params["passonnull"];    
+    var passOnNull = String(params["passonnull"]).toLowerCase();    
     var dependentValue = document.getElementById(dependentProperty).value;
 
     if (foolproof.is(value, operator, dependentValue, passOnNull))

--- a/Foolproof/Client Scripts/mvcfoolproof.unobtrusive.js
+++ b/Foolproof/Client Scripts/mvcfoolproof.unobtrusive.js
@@ -1,6 +1,6 @@
 ﻿var foolproof = function () { };
 foolproof.is = function (value1, operator, value2, passOnNull) {
-    if (passOnNull) {
+    if (passOnNull === "true") {
         var isNullish = function (input) {
             return input == null || input == undefined || input == "";
         };
@@ -69,7 +69,7 @@ foolproof.getName = function (element, dependentPropety) {
     jQuery.validator.addMethod("is", function (value, element, params) {
         var dependentProperty = foolproof.getId(element, params["dependentproperty"]);
         var operator = params["operator"];
-        var passOnNull = params["passonnull"];
+        var passOnNull = String(params["passonnull"]).toLowerCase();
         var dependentValue = document.getElementById(dependentProperty).value;
 
         if (foolproof.is(value, operator, dependentValue, passOnNull))


### PR DESCRIPTION
Correct the passOnNull check to account for the fact that passOnNull is a string and C# ToString() operations for bool values return "True" or "False".

Current comparison against the passOnNull object will always pass because the string object itself is valid.